### PR TITLE
arguments.go - AddressArray

### DIFF
--- a/overflow/argument.go
+++ b/overflow/argument.go
@@ -340,8 +340,8 @@ func (a *FlowArgumentsBuilder) StringArray(value ...string) *FlowArgumentsBuilde
 	return a
 }
 
-// Argument add an AddressArray to the transaction
-func (a *FlowArgumentsBuilder) AddressArray(value ...string) *FlowArgumentsBuilder {
+// Argument add a RawAddressArray to the transaction
+func (a *FlowArgumentsBuilder) RawAddressArray(value ...string) *FlowArgumentsBuilder {
 	array := []cadence.Value{}
 	for _, val := range value {
 		address := flow.HexToAddress(val)

--- a/overflow/argument.go
+++ b/overflow/argument.go
@@ -340,6 +340,18 @@ func (a *FlowArgumentsBuilder) StringArray(value ...string) *FlowArgumentsBuilde
 	return a
 }
 
+// Argument add an AddressArray to the transaction
+func (a *FlowArgumentsBuilder) AddressArray(value ...string) *FlowArgumentsBuilder {
+	array := []cadence.Value{}
+	for _, val := range value {
+		address := flow.HexToAddress(val)
+		cadenceAddress := cadence.BytesToAddress(address.Bytes())
+		array = append(array, cadenceAddress)
+	}
+	a.Arguments = append(a.Arguments, cadence.NewArray(array))
+	return a
+}
+
 // Argument add an argument to the transaction
 func (a *FlowArgumentsBuilder) UInt64Array(value ...uint64) *FlowArgumentsBuilder {
 	array := []cadence.Value{}

--- a/overflow/argument.go
+++ b/overflow/argument.go
@@ -341,7 +341,7 @@ func (a *FlowArgumentsBuilder) StringArray(value ...string) *FlowArgumentsBuilde
 }
 
 // Argument add an AddressArray to the transaction
-func (a *FlowArgumentsBuilder) AddressArray(value ...string) *FlowArgumentsBuilder {
+func (a *FlowArgumentsBuilder) RawAddressArray(value ...string) *FlowArgumentsBuilder {
 	array := []cadence.Value{}
 	for _, val := range value {
 		address := flow.HexToAddress(val)

--- a/overflow/argument_test.go
+++ b/overflow/argument_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,14 +24,21 @@ func TestArguments(t *testing.T) {
 		foo, _ := cadence.NewString("foo")
 		bar, _ := cadence.NewString("bar")
 
+		address1 := flow.HexToAddress("f8d6e0586b0a20c7")
+		address2 := flow.HexToAddress("01cf0e2f2f715450")
+		cadenceAddress1 := cadence.BytesToAddress(address1.Bytes())
+		cadenceAddress2 := cadence.BytesToAddress(address2.Bytes())
+
 		stringValues := []cadence.Value{foo, bar}
+		addressValues := []cadence.Value{cadenceAddress1, cadenceAddress2}
 
 		builder := g.Arguments().Boolean(true).
 			Bytes([]byte{1}).
 			Fix64("-1.0").
 			UFix64(1.0).
 			DateStringAsUnixTimestamp("July 29, 2021 08:00:00 AM", "America/New_York").
-			StringArray("foo", "bar")
+			StringArray("foo", "bar").
+			AddressArray("f8d6e0586b0a20c7", "01cf0e2f2f715450")
 
 		assert.Contains(t, builder.Arguments, cadence.NewBool(true))
 		assert.Contains(t, builder.Arguments, cadence.NewBytes([]byte{1}))
@@ -38,6 +46,7 @@ func TestArguments(t *testing.T) {
 		assert.Contains(t, builder.Arguments, ufix)
 		assert.Contains(t, builder.Arguments, dateFix)
 		assert.Contains(t, builder.Arguments, cadence.NewArray(stringValues))
+		assert.Contains(t, builder.Arguments, cadence.NewArray(addressValues))
 	})
 
 	t.Run("Word argument test", func(t *testing.T) {

--- a/overflow/argument_test.go
+++ b/overflow/argument_test.go
@@ -38,7 +38,7 @@ func TestArguments(t *testing.T) {
 			UFix64(1.0).
 			DateStringAsUnixTimestamp("July 29, 2021 08:00:00 AM", "America/New_York").
 			StringArray("foo", "bar").
-			AddressArray("f8d6e0586b0a20c7", "01cf0e2f2f715450")
+			RawAddressArray("f8d6e0586b0a20c7", "01cf0e2f2f715450")
 
 		assert.Contains(t, builder.Arguments, cadence.NewBool(true))
 		assert.Contains(t, builder.Arguments, cadence.NewBytes([]byte{1}))


### PR DESCRIPTION
Append an array of cadence addresses to arguments to script or transaction
Adds Coverage in for AddressArray in argument_test.go