### PR TITLE
fixes float64 to UFix64 rounding errors

### DIFF
--- a/overflow/argument.go
+++ b/overflow/argument.go
@@ -288,7 +288,7 @@ func parseTime(timeString string, location string) (string, error) {
 
 // UFix64 add a UFix64 Argument to the transaction
 func (a *FlowArgumentsBuilder) UFix64(input float64) *FlowArgumentsBuilder {
-	value := fmt.Sprintf("%f", input)
+	value := fmt.Sprintf("%.8f", input)
 	amount, err := cadence.NewUFix64(value)
 	if err != nil {
 		a.Error = err


### PR DESCRIPTION
ran into some issues with floats64 being rounded to 6 decimal places by default not 8 as per UFix64 limits 
