### PR TITLE
preserve response types in Cadence -> Interface conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/onflow/flow-go-sdk v0.26.4
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.26.1
-	github.com/sanity-io/litter v1.5.5
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.8.2
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -283,7 +283,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/dapperlabs/testingdock v0.4.2/go.mod h1:S45YfB1J1mbOeLHhJROx3dFZfMCVSxTgSU9vZ15Oq18=
 github.com/dapperlabs/testingdock v0.4.4/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
-github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -1539,7 +1538,6 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
-github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
@@ -1638,8 +1636,6 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDNxqmyJ6RfDFM=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
-github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/schollz/progressbar/v3 v3.7.6/go.mod h1:Y9mmL2knZj3LUaBDyBEzFdPrymIr08hnlFMZmfxwbx4=
 github.com/schollz/progressbar/v3 v3.8.3/go.mod h1:pWnVCjSBZsT2X3nx9HfRdnCDrpbevliMeoEVhStwHko=
@@ -1746,7 +1742,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/overflow/cadence.go
+++ b/overflow/cadence.go
@@ -66,7 +66,7 @@ func CadenceValueToInterface(field cadence.Value) interface{} {
 				return field.ToGoValue()
 			}
 
-			return field.String()
+			return CadenceValueToGoValue(field)
 		}
 		return result
 	}

--- a/overflow/cadence_test.go
+++ b/overflow/cadence_test.go
@@ -46,19 +46,64 @@ func TestCadenceValueToJsonString(t *testing.T) {
 	})
 
 	t.Run("Dictionary with numbers", func(t *testing.T) {
+		// fixed point numbers
 		fix64, err := cadence.NewFix64("1.12345678")
 		assert.Nil(t, err)
 		ufix64, err := cadence.NewUFix64("2.12345678")
 		assert.Nil(t, err)
 
+		// unsigned integers
+		uint256Val := cadence.NewUInt256(256)
+		uint128Val := cadence.NewUInt128(128)
+		uint64Val := cadence.NewUInt64(64)
+		uint32Val := cadence.NewUInt32(32)
+		uint16Val := cadence.NewUInt16(16)
+		uint8Val := cadence.NewUInt8(8)
+
+		// integers
+		int256Val := cadence.NewInt256(256)
+		int128Val := cadence.NewInt256(128)
+		int64Val := cadence.NewInt64(64)
+		int32Val := cadence.NewInt32(32)
+		int16Val := cadence.NewInt16(16)
+		int8Val := cadence.NewInt8(16)
+
+		boolVal := cadence.NewBool(false)
+
 		dict := cadence.NewDictionary([]cadence.KeyValuePair{
 			{Key: CadenceString("fix64"), Value: fix64},
 			{Key: CadenceString("ufix64"), Value: ufix64},
+			{Key: CadenceString("uint256"), Value: uint256Val},
+			{Key: CadenceString("uint128"), Value: uint128Val},
+			{Key: CadenceString("uint64"), Value: uint64Val},
+			{Key: CadenceString("uint32"), Value: uint32Val},
+			{Key: CadenceString("uint16"), Value: uint16Val},
+			{Key: CadenceString("uint8"), Value: uint8Val},
+			{Key: CadenceString("int256"), Value: int256Val},
+			{Key: CadenceString("int128"), Value: int128Val},
+			{Key: CadenceString("int64"), Value: int64Val},
+			{Key: CadenceString("int32"), Value: int32Val},
+			{Key: CadenceString("int16"), Value: int16Val},
+			{Key: CadenceString("int8"), Value: int8Val},
+			{Key: CadenceString("bool"), Value: boolVal},
 		})
 		value := CadenceValueToJsonString(dict)
 		assert.Equal(t, `{
+    "bool": false,
     "fix64": 1.12345678,
-    "ufix64": 2.12345678
+    "int128": 128,
+    "int16": 16,
+    "int256": 256,
+    "int32": 32,
+    "int64": 64,
+    "int8": 16,
+    "ufix64": 2.12345678,
+    "uint128": 128,
+    "uint16": 16,
+    "uint256": 256,
+    "uint32": 32,
+    "uint64": 64,
+    "uint8": 8
 }`, value)
 	})
 

--- a/overflow/cadence_test.go
+++ b/overflow/cadence_test.go
@@ -45,6 +45,23 @@ func TestCadenceValueToJsonString(t *testing.T) {
 }`, value)
 	})
 
+	t.Run("Dictionary with numbers", func(t *testing.T) {
+		fix64, err := cadence.NewFix64("1.12345678")
+		assert.Nil(t, err)
+		ufix64, err := cadence.NewUFix64("2.12345678")
+		assert.Nil(t, err)
+
+		dict := cadence.NewDictionary([]cadence.KeyValuePair{
+			{Key: CadenceString("fix64"), Value: fix64},
+			{Key: CadenceString("ufix64"), Value: ufix64},
+		})
+		value := CadenceValueToJsonString(dict)
+		assert.Equal(t, `{
+    "fix64": 1.12345678,
+    "ufix64": 2.12345678
+}`, value)
+	})
+
 	t.Run("Dictionary nested", func(t *testing.T) {
 		subDict := cadence.NewDictionary([]cadence.KeyValuePair{{Key: CadenceString("foo"), Value: CadenceString("bar")}})
 		dict := cadence.NewDictionary([]cadence.KeyValuePair{{Key: CadenceString("foo"), Value: CadenceString("bar")}, {Key: CadenceString("subdict"), Value: subDict}})

--- a/overflow/cadence_test.go
+++ b/overflow/cadence_test.go
@@ -123,7 +123,7 @@ func TestCadenceValueToJsonString(t *testing.T) {
 		dict := cadence.NewDictionary([]cadence.KeyValuePair{{Key: cadence.NewUInt64(1), Value: cadence.NewUInt64(1)}})
 		value := CadenceValueToJsonString(dict)
 		assert.Equal(t, `{
-    "1": "1"
+    "1": 1
 }`, value)
 	})
 

--- a/overflow/event.go
+++ b/overflow/event.go
@@ -346,7 +346,7 @@ func (e FormatedEvent) String() string {
 
 func (e FormatedEvent) GetFieldAsUInt64(field string) uint64 {
 	id := e.Fields[field]
-	fieldAsString := fmt.Sprintf("%s", id)
+	fieldAsString := fmt.Sprintf("%v", id)
 	if fieldAsString == "" {
 		panic("field is empty")
 	}

--- a/overflow/script_integration_test.go
+++ b/overflow/script_integration_test.go
@@ -118,7 +118,7 @@ pub struct Report{
 			NamedArguments(map[string]string{}).
 			RunReturnsInterface()
 
-		assert.Equal(t, "4", value)
+		assert.Equal(t, uint64(4), value)
 	})
 
 }

--- a/overflow/templates.go
+++ b/overflow/templates.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -168,14 +167,8 @@ pub fun main(user:Address): UInt64{
 	let account=getAccount(user)
 	return account.storageCapacity - account.storageUsed
 }
-`).Args(f.Arguments().Account(accountName)).RunReturnsInterface().(string)
-
-	intVar, err := strconv.Atoi(result)
-	if err != nil {
-		panic(err)
-	}
-
-	return intVar
+`).Args(f.Arguments().Account(accountName)).RunReturnsInterface().(uint64)
+	return int(result)
 
 }
 

--- a/overflow/transaction_integration_test.go
+++ b/overflow/transaction_integration_test.go
@@ -54,12 +54,12 @@ func TestTransactionIntegration(t *testing.T) {
 			}).
 			Test(t).
 			AssertSuccess().
-			AssertEventCount(3).                                                                                                                                                                           //assert the number of events returned
-			AssertPartialEvent(NewTestEvent("A.0ae53cb6e3f42a79.FlowToken.TokensDeposited", map[string]interface{}{"amount": "100.00000000"})).                                                            //assert a given event, can also take multiple events if you like
-			AssertEmitEventNameShortForm("FlowToken.TokensMinted").                                                                                                                                        //assert the name of a single event
-			AssertEmitEventName("A.0ae53cb6e3f42a79.FlowToken.TokensMinted", "A.0ae53cb6e3f42a79.FlowToken.TokensDeposited", "A.0ae53cb6e3f42a79.FlowToken.MinterCreated").                                //or assert more then one eventname in a go
-			AssertEmitEvent(NewTestEvent("A.0ae53cb6e3f42a79.FlowToken.TokensMinted", map[string]interface{}{"amount": "100.00000000"})).                                                                  //assert a given event, can also take multiple events if you like
-			AssertEmitEventJson("{\n  \"name\": \"A.0ae53cb6e3f42a79.FlowToken.MinterCreated\",\n  \"time\": \"1970-01-01T00:00:00Z\",\n  \"fields\": {\n    \"allowedAmount\": \"100.00000000\"\n  }\n}") //assert a given event using json, can also take multiple events if you like
+			AssertEventCount(3).                                                                                                                                                              //assert the number of events returned
+			AssertPartialEvent(NewTestEvent("A.0ae53cb6e3f42a79.FlowToken.TokensDeposited", map[string]interface{}{"amount": 100.00000000})).                                                 //assert a given event, can also take multiple events if you like
+			AssertEmitEventNameShortForm("FlowToken.TokensMinted").                                                                                                                           //assert the name of a single event
+			AssertEmitEventName("A.0ae53cb6e3f42a79.FlowToken.TokensMinted", "A.0ae53cb6e3f42a79.FlowToken.TokensDeposited", "A.0ae53cb6e3f42a79.FlowToken.MinterCreated").                   //or assert more then one eventname in a go
+			AssertEmitEvent(NewTestEvent("A.0ae53cb6e3f42a79.FlowToken.TokensMinted", map[string]interface{}{"amount": float64(100)})).                                                       //assert a given event, can also take multiple events if you like
+			AssertEmitEventJson("{\n  \"name\": \"A.0ae53cb6e3f42a79.FlowToken.MinterCreated\",\n  \"time\": \"1970-01-01T00:00:00Z\",\n  \"fields\": {\n    \"allowedAmount\": 100\n  }\n}") //assert a given event using json, can also take multiple events if you like
 
 		assert.Equal(t, 1, len(result.Result.GetEventsWithName("A.0ae53cb6e3f42a79.FlowToken.TokensDeposited")))
 		assert.Equal(t, 1, len(result.Result.GetEventsWithName("A.0ae53cb6e3f42a79.FlowToken.TokensDeposited")))

--- a/overflow/utils.go
+++ b/overflow/utils.go
@@ -1,6 +1,8 @@
 package overflow
 
-import "github.com/onflow/cadence"
+import (
+	"github.com/onflow/cadence"
+)
 
 const (
 	fixedPointrecisionMultiple = 100000000
@@ -25,7 +27,7 @@ func CadenceValueToGoValue(input cadence.Value) (output interface{}) {
 		output = float64(val.(int64)) / fixedPointrecisionMultiple
 		break
 	default:
-		output = input.ToGoValue()
+		output = val
 	}
 	return
 }

--- a/overflow/utils.go
+++ b/overflow/utils.go
@@ -2,10 +2,30 @@ package overflow
 
 import "github.com/onflow/cadence"
 
+const (
+	fixedPointrecisionMultiple = 100000000
+)
+
 func CadenceString(input string) cadence.String {
 	value, err := cadence.NewString(input)
 	if err != nil {
 		panic(err)
 	}
 	return value
+}
+
+func CadenceValueToGoValue(input cadence.Value) (output interface{}) {
+	val := input.ToGoValue()
+	switch input.(type) {
+	// TODO: can these be handled together?
+	case cadence.UFix64:
+		output = float64(val.(uint64)) / fixedPointrecisionMultiple
+		break
+	case cadence.Fix64:
+		output = float64(val.(int64)) / fixedPointrecisionMultiple
+		break
+	default:
+		output = input.ToGoValue()
+	}
+	return
 }

--- a/overflow/utils.go
+++ b/overflow/utils.go
@@ -21,13 +21,12 @@ func CadenceValueToGoValue(input cadence.Value) (output interface{}) {
 	switch input.(type) {
 	// TODO: can these be handled together?
 	case cadence.UFix64:
-		output = float64(val.(uint64)) / fixedPointrecisionMultiple
-		break
+		return float64(val.(uint64)) / fixedPointrecisionMultiple
 	case cadence.Fix64:
-		output = float64(val.(int64)) / fixedPointrecisionMultiple
-		break
+		return float64(val.(int64)) / fixedPointrecisionMultiple
+	case cadence.Address:
+		return input.String()
 	default:
-		output = val
+		return val
 	}
-	return
 }


### PR DESCRIPTION
Currently everything in the overflow json response from a cadence value are all strings. This changes that and attempts to preserve the type of the cadence value