### PR TITLE
TxFN should not store whats in previous tx

### DIFF
--- a/state.go
+++ b/state.go
@@ -538,17 +538,16 @@ func (o OverflowState) readLog() ([]OverflowEmulatorLogMessage, error) {
 func (o *OverflowState) TxFN(outerOpts ...OverflowInteractionOption) OverflowTransactionFunction {
 
 	return func(filename string, opts ...OverflowInteractionOption) *OverflowResult {
-		outerOpts = append(outerOpts, opts...)
-		return o.Tx(filename, outerOpts...)
-
+		opts = append(opts, outerOpts...)
+		return o.Tx(filename, opts...)
 	}
 }
 
 func (o *OverflowState) TxFileNameFN(filename string, outerOpts ...OverflowInteractionOption) OverflowTransactionOptsFunction {
 
 	return func(opts ...OverflowInteractionOption) *OverflowResult {
-		outerOpts = append(outerOpts, opts...)
-		return o.Tx(filename, outerOpts...)
+		opts = append(opts, outerOpts...)
+		return o.Tx(filename, opts...)
 	}
 }
 


### PR DESCRIPTION
## Description

TxFN and TxFNFileName should not put previous call on opts into outerOps. 

______

For contributor use:

- [ ] Targeted PR against `main` branch
- [ ] Code follows the [standards mentioned here](https://github.com/bjartek/overflow/blob/main/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer

