### PR TITLE
support Event type in CadenceValueToInterface

### DIFF
--- a/cadence.go
+++ b/cadence.go
@@ -160,7 +160,17 @@ func CadenceValueToInterface(field cadence.Value) interface{} {
 	case cadence.Fix64:
 		float, _ := strconv.ParseFloat(field.String(), 64)
 		return float
+	case cadence.Event:
+		result := map[string]interface{}{}
 
+		for i, subField := range field.Fields {
+			value := CadenceValueToInterface(subField)
+			if value != nil {
+				result[field.EventType.Fields[i].Identifier] = value
+			}
+		}
+
+		return result
 	default:
 		//fmt.Println("is fallthrough ", field.ToGoValue(), " ", field.String())
 


### PR DESCRIPTION
## Description

Needed to "borrow" the code from CadenceValueToInterface and discovered it does not support the cadence.Event type. I have added support and wanted to pass the changes along

______

For contributor use:

- [ ] Targeted PR against `main` branch
- [ ] Code follows the [standards mentioned here](https://github.com/bjartek/overflow/blob/main/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer

