### PR TITLE
fix: NoneLog should exclude printing message not include

### DIFF
--- a/state.go
+++ b/state.go
@@ -453,7 +453,7 @@ func (o *OverflowState) CreateAccountsE(ctx context.Context) (*OverflowState, er
 			messages = append(messages, "with flow:", fmt.Sprintf("%.2f", o.NewUserFlowAmount))
 		}
 
-		if o.PrintOptions != nil && o.LogLevel == output.NoneLog {
+		if o.PrintOptions != nil && o.LogLevel != output.NoneLog {
 			fmt.Println(strings.Join(messages, " "))
 		}
 	}


### PR DESCRIPTION
## Description

Seems like the NoneLog setting should prevent the create account logs from showing not be required for them to show. I think this is a typo and the fix proposed fixes that.

______

For contributor use:

- [X] Targeted PR against `main` branch
- [X] Code follows the [standards mentioned here](https://github.com/bjartek/overflow/blob/main/CONTRIBUTING.md#styleguides)
- [X] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the Github PR explorer

